### PR TITLE
feat: :art: Configure prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,6 @@
 .env.test.local
 .env.production.local
 .editorconfig
-.prettierrc
-.prettierignore
 /.vscode
 
 npm-debug.log*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+build/
+package.json
+package-lock.json

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,5 @@
+---
+trailingComma: 'es5'
+tabWidth: 2
+semi: true
+singleQuote: true

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "cross-env": "^7.0.2",
     "electron": "^11.0.1",
     "electron-builder": "^22.9.1",
+    "prettier": "^2.6.2",
     "typescript": "^4.6.3",
     "wait-on": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9918,6 +9918,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+
 pretty-bytes@^5.1.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.4.1.tgz#cd89f79bbcef21e3d21eb0da68ffe93f803e884b"


### PR DESCRIPTION
Making `prettier` as default option for code formatting.
Today it is kind of standard.

- Add prettier to dev deps
- Add prettierrc
- Update gitignore